### PR TITLE
Fix accounting for validator deposits

### DIFF
--- a/packages/subgraph-gnosis-chain/abis/SBCDepositContract.json
+++ b/packages/subgraph-gnosis-chain/abis/SBCDepositContract.json
@@ -1,0 +1,194 @@
+[
+  {
+    "type": "constructor",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      { "type": "address", "name": "_token", "internalType": "address" }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "DepositEvent",
+    "inputs": [
+      {
+        "type": "bytes",
+        "name": "pubkey",
+        "internalType": "bytes",
+        "indexed": false
+      },
+      {
+        "type": "bytes",
+        "name": "withdrawal_credentials",
+        "internalType": "bytes",
+        "indexed": false
+      },
+      {
+        "type": "bytes",
+        "name": "amount",
+        "internalType": "bytes",
+        "indexed": false
+      },
+      {
+        "type": "bytes",
+        "name": "signature",
+        "internalType": "bytes",
+        "indexed": false
+      },
+      {
+        "type": "bytes",
+        "name": "index",
+        "internalType": "bytes",
+        "indexed": false
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Paused",
+    "inputs": [
+      {
+        "type": "address",
+        "name": "account",
+        "internalType": "address",
+        "indexed": false
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Unpaused",
+    "inputs": [
+      {
+        "type": "address",
+        "name": "account",
+        "internalType": "address",
+        "indexed": false
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "outputs": [],
+    "name": "batchDeposit",
+    "inputs": [
+      { "type": "bytes", "name": "pubkeys", "internalType": "bytes" },
+      {
+        "type": "bytes",
+        "name": "withdrawal_credentials",
+        "internalType": "bytes"
+      },
+      { "type": "bytes", "name": "signatures", "internalType": "bytes" },
+      {
+        "type": "bytes32[]",
+        "name": "deposit_data_roots",
+        "internalType": "bytes32[]"
+      }
+    ]
+  },
+  {
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "outputs": [],
+    "name": "claimTokens",
+    "inputs": [
+      { "type": "address", "name": "_token", "internalType": "address" },
+      { "type": "address", "name": "_to", "internalType": "address" }
+    ]
+  },
+  {
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "outputs": [],
+    "name": "deposit",
+    "inputs": [
+      { "type": "bytes", "name": "pubkey", "internalType": "bytes" },
+      {
+        "type": "bytes",
+        "name": "withdrawal_credentials",
+        "internalType": "bytes"
+      },
+      { "type": "bytes", "name": "signature", "internalType": "bytes" },
+      {
+        "type": "bytes32",
+        "name": "deposit_data_root",
+        "internalType": "bytes32"
+      },
+      { "type": "uint256", "name": "stake_amount", "internalType": "uint256" }
+    ]
+  },
+  {
+    "type": "function",
+    "stateMutability": "view",
+    "outputs": [{ "type": "bytes", "name": "", "internalType": "bytes" }],
+    "name": "get_deposit_count",
+    "inputs": []
+  },
+  {
+    "type": "function",
+    "stateMutability": "view",
+    "outputs": [{ "type": "bytes32", "name": "", "internalType": "bytes32" }],
+    "name": "get_deposit_root",
+    "inputs": []
+  },
+  {
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "outputs": [{ "type": "bool", "name": "", "internalType": "bool" }],
+    "name": "onTokenTransfer",
+    "inputs": [
+      { "type": "address", "name": "", "internalType": "address" },
+      { "type": "uint256", "name": "stake_amount", "internalType": "uint256" },
+      { "type": "bytes", "name": "data", "internalType": "bytes" }
+    ]
+  },
+  {
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "outputs": [],
+    "name": "pause",
+    "inputs": []
+  },
+  {
+    "type": "function",
+    "stateMutability": "view",
+    "outputs": [{ "type": "bool", "name": "", "internalType": "bool" }],
+    "name": "paused",
+    "inputs": []
+  },
+  {
+    "type": "function",
+    "stateMutability": "view",
+    "outputs": [
+      { "type": "address", "name": "", "internalType": "contract IERC20" }
+    ],
+    "name": "stake_token",
+    "inputs": []
+  },
+  {
+    "type": "function",
+    "stateMutability": "pure",
+    "outputs": [{ "type": "bool", "name": "", "internalType": "bool" }],
+    "name": "supportsInterface",
+    "inputs": [
+      { "type": "bytes4", "name": "interfaceId", "internalType": "bytes4" }
+    ]
+  },
+  {
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "outputs": [],
+    "name": "unpause",
+    "inputs": []
+  },
+  {
+    "type": "function",
+    "stateMutability": "view",
+    "outputs": [{ "type": "bytes32", "name": "", "internalType": "bytes32" }],
+    "name": "validator_withdrawal_credentials",
+    "inputs": [{ "type": "bytes", "name": "", "internalType": "bytes" }]
+  }
+]

--- a/packages/subgraph-gnosis-chain/abis/sbcWrapper.json
+++ b/packages/subgraph-gnosis-chain/abis/sbcWrapper.json
@@ -1,0 +1,234 @@
+[
+  {
+    "type": "constructor",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      {
+        "type": "address",
+        "name": "_sbcToken",
+        "internalType": "contract SBCToken"
+      },
+      {
+        "type": "address",
+        "name": "_depositContract",
+        "internalType": "contract SBCDepositContract"
+      }
+    ]
+  },
+  {
+    "type": "event",
+    "name": "Paused",
+    "inputs": [
+      {
+        "type": "address",
+        "name": "account",
+        "internalType": "address",
+        "indexed": false
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Swap",
+    "inputs": [
+      {
+        "type": "address",
+        "name": "token",
+        "internalType": "address",
+        "indexed": true
+      },
+      {
+        "type": "address",
+        "name": "user",
+        "internalType": "address",
+        "indexed": true
+      },
+      {
+        "type": "uint256",
+        "name": "amount",
+        "internalType": "uint256",
+        "indexed": false
+      },
+      {
+        "type": "uint256",
+        "name": "received",
+        "internalType": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "SwapRateUpdated",
+    "inputs": [
+      {
+        "type": "address",
+        "name": "token",
+        "internalType": "address",
+        "indexed": true
+      },
+      {
+        "type": "uint256",
+        "name": "rate",
+        "internalType": "uint256",
+        "indexed": false
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "TokenSwapEnabled",
+    "inputs": [
+      {
+        "type": "address",
+        "name": "token",
+        "internalType": "address",
+        "indexed": true
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "TokenSwapPaused",
+    "inputs": [
+      {
+        "type": "address",
+        "name": "token",
+        "internalType": "address",
+        "indexed": true
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "event",
+    "name": "Unpaused",
+    "inputs": [
+      {
+        "type": "address",
+        "name": "account",
+        "internalType": "address",
+        "indexed": false
+      }
+    ],
+    "anonymous": false
+  },
+  {
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "outputs": [],
+    "name": "claimTokens",
+    "inputs": [
+      { "type": "address", "name": "_token", "internalType": "address" },
+      { "type": "address", "name": "_to", "internalType": "address" }
+    ]
+  },
+  {
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "outputs": [],
+    "name": "enableToken",
+    "inputs": [
+      { "type": "address", "name": "_token", "internalType": "address" },
+      { "type": "uint256", "name": "_rate", "internalType": "uint256" }
+    ]
+  },
+  {
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "outputs": [{ "type": "bool", "name": "", "internalType": "bool" }],
+    "name": "onTokenTransfer",
+    "inputs": [
+      { "type": "address", "name": "from", "internalType": "address" },
+      { "type": "uint256", "name": "value", "internalType": "uint256" },
+      { "type": "bytes", "name": "data", "internalType": "bytes" }
+    ]
+  },
+  {
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "outputs": [],
+    "name": "pause",
+    "inputs": []
+  },
+  {
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "outputs": [],
+    "name": "pauseToken",
+    "inputs": [
+      { "type": "address", "name": "_token", "internalType": "address" }
+    ]
+  },
+  {
+    "type": "function",
+    "stateMutability": "view",
+    "outputs": [{ "type": "bool", "name": "", "internalType": "bool" }],
+    "name": "paused",
+    "inputs": []
+  },
+  {
+    "type": "function",
+    "stateMutability": "view",
+    "outputs": [
+      {
+        "type": "address",
+        "name": "",
+        "internalType": "contract SBCDepositContract"
+      }
+    ],
+    "name": "sbcDepositContract",
+    "inputs": []
+  },
+  {
+    "type": "function",
+    "stateMutability": "view",
+    "outputs": [
+      { "type": "address", "name": "", "internalType": "contract SBCToken" }
+    ],
+    "name": "sbcToken",
+    "inputs": []
+  },
+  {
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "outputs": [],
+    "name": "swap",
+    "inputs": [
+      { "type": "address", "name": "_token", "internalType": "address" },
+      { "type": "uint256", "name": "_amount", "internalType": "uint256" },
+      { "type": "bytes", "name": "_permitData", "internalType": "bytes" }
+    ]
+  },
+  {
+    "type": "function",
+    "stateMutability": "view",
+    "outputs": [{ "type": "uint256", "name": "", "internalType": "uint256" }],
+    "name": "tokenRate",
+    "inputs": [{ "type": "address", "name": "", "internalType": "address" }]
+  },
+  {
+    "type": "function",
+    "stateMutability": "view",
+    "outputs": [
+      {
+        "type": "uint8",
+        "name": "",
+        "internalType": "enum SBCWrapper.TokenStatus"
+      }
+    ],
+    "name": "tokenStatus",
+    "inputs": [{ "type": "address", "name": "", "internalType": "address" }]
+  },
+  {
+    "type": "function",
+    "stateMutability": "nonpayable",
+    "outputs": [],
+    "name": "unpause",
+    "inputs": []
+  }
+]

--- a/packages/subgraph-gnosis-chain/src/deposit.ts
+++ b/packages/subgraph-gnosis-chain/src/deposit.ts
@@ -1,0 +1,14 @@
+import { BigInt } from "@graphprotocol/graph-ts";
+import { DepositEvent } from "../generated/ds-deposit/SBCDepositContract";
+import { loadOrCreateUser } from "./helpers";
+
+const ONE_GNO = BigInt.fromString("1000000000000000000");
+
+export function handleDeposit(event: DepositEvent): void {
+  const user = event.transaction.from;
+
+  const entry = loadOrCreateUser(user);
+  entry.deposit = entry.deposit.plus(ONE_GNO);
+  entry.voteWeight = entry.voteWeight.plus(ONE_GNO);
+  entry.save();
+}

--- a/packages/subgraph-gnosis-chain/src/mgno.ts
+++ b/packages/subgraph-gnosis-chain/src/mgno.ts
@@ -16,11 +16,7 @@ export function handleTransfer(event: Transfer): void {
   if (from.toHexString() != ADDRESS_ZERO.toHexString()) {
     const userFrom = loadOrCreateUser(from);
     userFrom.mgno = userFrom.mgno.minus(value);
-    if (to.toHexString() == DEPOSIT_ADDRESS.toHexString()) {
-      userFrom.deposit = userFrom.deposit.plus(value.div(MGNO_PER_GNO));
-    } else {
-      userFrom.voteWeight = userFrom.voteWeight.minus(value.div(MGNO_PER_GNO));
-    }
+    userFrom.voteWeight = userFrom.voteWeight.minus(value.div(MGNO_PER_GNO));
     removeOrSaveUser(userFrom);
   }
 

--- a/packages/subgraph-gnosis-chain/subgraph.yaml
+++ b/packages/subgraph-gnosis-chain/subgraph.yaml
@@ -62,6 +62,26 @@ dataSources:
         - event: Transfer(indexed address,indexed address,uint256)
           handler: handleTransfer
       file: ../subgraph-base/src/lgno.ts
+  - kind: ethereum
+    name: ds-deposit
+    network: xdai
+    source:
+      address: "0x0B98057eA310F4d31F2a452B414647007d1645d9"
+      abi: SBCDepositContract
+      startBlock: 19469077
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.6
+      language: wasm/assemblyscript
+      entities:
+        - User
+      abis:
+        - name: SBCDepositContract
+          file: ./abis/SBCDepositContract.json
+      eventHandlers:
+        - event: DepositEvent(bytes,bytes,bytes,bytes,bytes)
+          handler: handleDeposit
+      file: ./src/deposit.ts
   - kind: ethereum/contract
     name: HoneySwap
     network: xdai

--- a/packages/subgraph-gnosis-chain/tests/deposit.test.ts
+++ b/packages/subgraph-gnosis-chain/tests/deposit.test.ts
@@ -1,0 +1,84 @@
+import { clearStore, test, assert } from "matchstick-as/assembly/index";
+import { Address, BigInt, ethereum } from "@graphprotocol/graph-ts";
+import { handleDeposit } from "../src/deposit";
+import { DepositEvent } from "../generated/ds-deposit/SBCDepositContract";
+import { log, newMockEvent } from "matchstick-as";
+import {
+  ADDRESS_ZERO,
+  ONE_GNO,
+  MGNO_PER_GNO,
+  DEPOSIT_ADDRESS,
+  USER1_ADDRESS,
+  USER2_ADDRESS,
+  data,
+} from "./helpers";
+
+let value = ONE_GNO.times(MGNO_PER_GNO);
+let value2x = value.times(BigInt.fromI32(2));
+
+function createDepositEvent(
+  from: string,
+  to: string,
+  value: BigInt,
+  data: string
+): DepositEvent {
+  let mockEvent = newMockEvent();
+
+  let newTransferEvent = new DepositEvent(
+    mockEvent.address,
+    mockEvent.logIndex,
+    mockEvent.transactionLogIndex,
+    mockEvent.logType,
+    mockEvent.block,
+    new ethereum.Transaction(
+      mockEvent.transaction.hash,
+      mockEvent.transaction.index,
+      Address.fromString(from),
+      mockEvent.transaction.to,
+      mockEvent.transaction.value,
+      mockEvent.transaction.gasLimit,
+      mockEvent.transaction.gasPrice,
+      mockEvent.transaction.input,
+      mockEvent.transaction.nonce
+    ),
+    mockEvent.parameters
+  );
+
+  return newTransferEvent;
+}
+
+test("Deposit increases the deposit amount of the sender by 1 GNO", () => {
+  clearStore();
+  handleDeposit(
+    createDepositEvent(
+      USER1_ADDRESS.toHexString(),
+      DEPOSIT_ADDRESS.toHexString(),
+      value,
+      data
+    )
+  );
+  assert.fieldEquals(
+    "User",
+    USER1_ADDRESS.toHexString(),
+    "deposit",
+    ONE_GNO.toString()
+  );
+});
+
+test("Deposit increases the vote weight of the sender by 1 GNO", () => {
+  clearStore();
+  handleDeposit(
+    createDepositEvent(
+      USER1_ADDRESS.toHexString(),
+      DEPOSIT_ADDRESS.toHexString(),
+      value,
+      data
+    )
+  );
+  assert.fieldEquals(
+    "User",
+    USER1_ADDRESS.toHexString(),
+    "voteWeight",
+    ONE_GNO.toString()
+  );
+});

--- a/packages/subgraph-gnosis-chain/tests/mgno.test.ts
+++ b/packages/subgraph-gnosis-chain/tests/mgno.test.ts
@@ -180,39 +180,6 @@ test("Transfer correctly decreases vote weight of sender", () => {
   );
 });
 
-test("Transfer to DEPOSIT_ADDRESS does not change vote weight", () => {
-  clearStore();
-  // mint value2x to USER1_ADDRESS
-  let mintEvent = createTransferEvent(
-    ADDRESS_ZERO.toHexString(),
-    USER1_ADDRESS.toHexString(),
-    value2x,
-    data
-  );
-  handleTransfer(mintEvent);
-  assert.fieldEquals(
-    "User",
-    USER1_ADDRESS.toHexString(),
-    "voteWeight",
-    value2x.div(MGNO_PER_GNO).toString()
-  );
-
-  // send value from USER1_ADDRESS to USER2_ADDRESS, user one should have value left
-  let transferEvent = createTransferEvent(
-    USER1_ADDRESS.toHexString(),
-    DEPOSIT_ADDRESS.toHexString(),
-    value,
-    data
-  );
-  handleTransfer(transferEvent);
-  assert.fieldEquals(
-    "User",
-    USER1_ADDRESS.toHexString(),
-    "voteWeight",
-    value2x.div(MGNO_PER_GNO).toString()
-  );
-});
-
 test("Transfer resulting in 0 vote weight removes user from store.", () => {
   clearStore();
   // mint value2x to USER1_ADDRESS


### PR DESCRIPTION
Turns out @cristovaoth already had this handled correctly, so it was only a matter of restoring his mapping code. I've cherry-picked the fix onto the `sans-uni` branch and started a deployment from that base: https://thegraph.com/hosted-service/subgraph/jfschwarz/gno-voting-power-gc-sans-uni

